### PR TITLE
fix warning about string literals

### DIFF
--- a/treasure-data-rest.h
+++ b/treasure-data-rest.h
@@ -31,7 +31,7 @@ class TreasureData_RESTAPI {
 
 public:
 
-	TreasureData_RESTAPI(NetworkInterface* aNetwork,char* aDatabase, char* aTable, const char *aAPIKey){
+	TreasureData_RESTAPI(NetworkInterface* aNetwork, const char* aDatabase, const char* aTable, const char *aAPIKey){
 		apikey 		= aAPIKey;
 		network 	= aNetwork;
 		table 		= aTable;
@@ -93,8 +93,8 @@ private:
 	NetworkInterface* network;
 	const char * apikey;
 	char apikeybuff[50];
-	char * table;
-	char * database;
+	const char * table;
+	const char * database;
 	char urlbuff [URL_SIZE];	// use for URL
 
 #if TD_DEBUG


### PR DESCRIPTION
added 'const' to remove warning complains for string literals

@BlackstoneEngineering mind to have a look and merge